### PR TITLE
Hotfix

### DIFF
--- a/ado/ipacheckids.ado
+++ b/ado/ipacheckids.ado
@@ -191,7 +191,14 @@ foreach id in `id_ordered' {
 	}
 	if "`save'" != "" {
 		preserve
-		drop _hfc* __*
+		qui cap ds _hfc* __*
+		foreach var in `r(varlist' {
+		cap confirm `var'
+		if _rc {
+			drop `var'
+		}
+		}
+		*drop _hfc* __*
 		save "`save'", replace
 		restore
 	}

--- a/ado/ipacheckids.ado
+++ b/ado/ipacheckids.ado
@@ -198,7 +198,7 @@ foreach id in `id_ordered' {
 			drop `var'
 		}
 		}
-		*drop _hfc* __*
+
 		save "`save'", replace
 		restore
 	}

--- a/ado/ipacheckids.ado
+++ b/ado/ipacheckids.ado
@@ -192,7 +192,7 @@ foreach id in `id_ordered' {
 	if "`save'" != "" {
 		preserve
 		qui cap ds _hfc* __*
-		foreach var in `r(varlist' {
+		foreach var in `r(varlist)' {
 		cap confirm `var'
 		if _rc {
 			drop `var'


### PR DESCRIPTION
dropping hfc vars and tempvars can cause an error if the variables don't exist. This fixes that by checking if  variables exist and dropping one by one. 